### PR TITLE
Add dimensions to the array type

### DIFF
--- a/bmi_map.py
+++ b/bmi_map.py
@@ -180,14 +180,14 @@ class Parameter:
         if not dtype.startswith("array"):
             raise ValueError("not an array type ({dtype})")
 
-        rank, dtype = Parameter.split_array_type(dtype)
+        dtype, dims = Parameter.split_array_type(dtype)
         if dtype not in Parameter.valid_array_types:
             raise ValueError(
                 f"array type not understood ({dtype} not one of"
                 f" {', '.join(repr(t) for t in sorted(Parameter.valid_array_types))})"
             )
 
-        return f"array[{rank!s}, {dtype}]"
+        return f"array[{', '.join((dtype,) + dims)}]"
 
     @staticmethod
     def validate_type(dtype: str) -> str:
@@ -197,11 +197,17 @@ class Parameter:
             return Parameter.validate_scalar(dtype)
 
     @staticmethod
-    def split_array_type(array_type: str) -> tuple[int, str]:
+    def split_array_type(array_type: str) -> tuple[str, tuple[str, ...]]:
         match = re.match(r"^array\[(.*?)\]$", array_type)
         if match:
-            rank, dtype = match.group(1).split(",")
-            return int(rank), dtype.strip()
+            parts = match.group(1).split(",")
+
+            dtype = parts[0].strip()
+            try:
+                dims = tuple(part.strip() for part in parts[1:])
+            except IndexError:
+                dims = ()
+            return dtype, dims
         else:
             raise ValueError(f"type not understood ({array_type})")
 
@@ -230,10 +236,13 @@ class SidlMapper(LanguageMapper):
     @staticmethod
     def map_type(dtype: str) -> str:
         if dtype.startswith("array"):
-            rank, dtype = Parameter.split_array_type(dtype)
+            dtype, dims = Parameter.split_array_type(dtype)
             if dtype == "any":
                 dtype = ""
-            return f"array<{dtype.strip()}, {rank}>"
+            if dims:
+                return f"array<{dtype.strip()}, {len(dims)}>"
+            else:
+                return f"array<{dtype.strip()},>"
         else:
             return dtype
 
@@ -260,7 +269,7 @@ class CMapper(LanguageMapper):
     @staticmethod
     def map_type(dtype: str) -> str:
         if dtype.startswith("array"):
-            _, array_type = Parameter.split_array_type(dtype)
+            array_type, _ = Parameter.split_array_type(dtype)
             if array_type == "any":
                 c_type = "void"
             else:
@@ -282,6 +291,10 @@ class CMapper(LanguageMapper):
             if intent == "in" or dtype == "string":
                 c_type = f"const {c_type}"
             c_params.append(f"{c_type} {name}")
+
+            if dtype.startswith("array"):
+                _, dims = Parameter.split_array_type(dtype)
+                c_params += [f"const int {dim}" for dim in dims]
 
         return ", ".join(c_params)
 
@@ -306,7 +319,7 @@ class CxxMapper(LanguageMapper):
     @staticmethod
     def map_type(dtype: str) -> str:
         if dtype.startswith("array"):
-            _, array_type = Parameter.split_array_type(dtype)
+            array_type, _ = Parameter.split_array_type(dtype)
             if array_type == "any":
                 cxx_type = "void"
             elif array_type == "string":
@@ -365,7 +378,7 @@ class PythonMapper(LanguageMapper):
     @staticmethod
     def map_type(dtype: str) -> str:
         if dtype.startswith("array"):
-            _, array_type = Parameter.split_array_type(dtype)
+            array_type, _ = Parameter.split_array_type(dtype)
             if array_type == "any":
                 py_type = "Any"
             elif array_type == "string":

--- a/bmi_map.py
+++ b/bmi_map.py
@@ -4,6 +4,7 @@ import argparse
 import re
 import sys
 import tomllib
+from collections import Counter
 from collections.abc import Sequence
 from functools import partial
 from typing import Any
@@ -185,6 +186,12 @@ class Parameter:
             raise ValueError(
                 f"array type not understood ({dtype} not one of"
                 f" {', '.join(repr(t) for t in sorted(Parameter.valid_array_types))})"
+            )
+        repeated_dims = [dim for dim, count in Counter(dims).items() if count > 1]
+        if repeated_dims:
+            raise ValueError(
+                f"repeated dimension{'s' if len(repeated_dims) > 1 else ''}"
+                f" ({', '.join(repeated_dims)})"
             )
 
         return f"array[{', '.join((dtype,) + dims)}]"

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -1,0 +1,26 @@
+import pytest
+
+from bmi_map import Parameter
+
+
+@pytest.mark.parametrize("array_type", ("int", "double", "string", "any"))
+@pytest.mark.parametrize("dims", ("", "m", "m,n", " m, n , o"))
+def test_array_is_valid(array_type, dims):
+    array_type, actual_dims = Parameter.split_array_type(
+        Parameter.validate_array(f"array[{','.join([array_type, dims])}]")
+    )
+
+    assert array_type == array_type
+    assert actual_dims == tuple(dim.strip() for dim in dims.split(","))
+
+
+@pytest.mark.parametrize("array_type", ("long", "float", "boolean", ""))
+def test_array_with_bad_type(array_type):
+    with pytest.raises(ValueError):
+        Parameter.validate_array(f"array[{array_type}]")
+
+
+@pytest.mark.parametrize("dims", ("m,m", "m,n,m"))
+def test_array_with_repeated_dims(dims):
+    with pytest.raises(ValueError):
+        Parameter.validate_array(f"array[any, {dims}]")

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -52,6 +52,25 @@ def test_c_array_intent(intent, expected):
 
 
 @pytest.mark.parametrize(
+    "dims,expected",
+    [
+        ("m", "int f(void* self, const int* a, const int m, const int* b);"),
+        (
+            "m,n",
+            "int f(void* self, const int* a, const int m, const int n, const int* b);",
+        ),
+    ],
+)
+def test_c_array_with_dimensions(dims, expected):
+    params = [
+        {"name": "a", "type": f"array[int,{dims}]", "intent": "in"},
+        {"name": "b", "type": "array[int]", "intent": "in"},
+    ]
+    mapped_func = bmi_map({"f": {"params": params}}, to="c")
+    assert mapped_func[0] == expected
+
+
+@pytest.mark.parametrize(
     "intent,expected",
     [
         ("in", "void Foo(const int a);"),

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -46,7 +46,7 @@ def test_c_two_parameter(a_intent, b_intent, expected):
     ],
 )
 def test_c_array_intent(intent, expected):
-    p = {"name": "a", "type": "array[1, int]", "intent": intent}
+    p = {"name": "a", "type": "array[int]", "intent": intent}
     mapped_func = bmi_map({"foo": {"params": [p]}}, to="c")
     assert mapped_func[0] == expected
 


### PR DESCRIPTION
This pull request adds array dimensions to the array type. The dimensions are (optionally) listed after the array type. For example:
* `array[int, m, n]`: an integer array of shape `m` by `n`.
* `array[int]`: an integer array of unspecified size.

When mapping to some languages (e.g. *c*), these dimensions will be added to the parameter list as input integers.