### PR TITLE
Create mappers subpackage to hold all the language mappers

### DIFF
--- a/src/bmi_map/bmi_map.py
+++ b/src/bmi_map/bmi_map.py
@@ -9,6 +9,7 @@ from bmi_map._mapper import LanguageMapper
 from bmi_map._parameter import Parameter
 from bmi_map.mappers.c import CMapper
 from bmi_map.mappers.cxx import CxxMapper
+from bmi_map.mappers.python import PythonMapper
 
 
 def bmi_map(
@@ -78,57 +79,3 @@ class SidlMapper(LanguageMapper):
                 for name, intent, dtype in params
             ]
         )
-
-
-class PythonMapper(LanguageMapper):
-    _type_mapping = {
-        "int": "int",
-        "double": "float",
-        "string": "str",
-    }
-
-    def map(self):
-        return (
-            f"def {self._name}({PythonMapper.map_params(self._params)})"
-            f" -> {PythonMapper.map_returns(self._params)}:"
-        )
-
-    @staticmethod
-    def map_type(dtype: str) -> str:
-        if dtype.startswith("array"):
-            array_type, _ = Parameter.split_array_type(dtype)
-            if array_type == "any":
-                py_type = "Any"
-            elif array_type == "string":
-                py_type = "tuple[str, ...]"
-            else:
-                py_type = PythonMapper.map_type(array_type)
-
-            if array_type != "string":
-                py_type = f"NDArray[{py_type}]"
-        else:
-            py_type = PythonMapper._type_mapping[dtype]
-        return py_type
-
-    @staticmethod
-    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
-        py_params = ["self"] + [
-            f"{name}: {PythonMapper.map_type(dtype)}"
-            for name, intent, dtype in params
-            if intent.startswith("in")
-        ]
-        return ", ".join(py_params)
-
-    @staticmethod
-    def map_returns(params: Sequence[tuple[str, str, str]]):
-        returns = [
-            PythonMapper.map_type(dtype)
-            for _, intent, dtype in params
-            if intent.endswith("out")
-        ]
-        if len(returns) == 0:
-            return "None"
-        elif len(returns) == 1:
-            return returns[0]
-        else:
-            return f"tuple[{', '.join(returns)}]"

--- a/src/bmi_map/bmi_map.py
+++ b/src/bmi_map/bmi_map.py
@@ -7,6 +7,7 @@ from typing import BinaryIO
 
 from bmi_map._mapper import LanguageMapper
 from bmi_map._parameter import Parameter
+from bmi_map.mappers.c import CMapper
 
 
 def bmi_map(
@@ -76,49 +77,6 @@ class SidlMapper(LanguageMapper):
                 for name, intent, dtype in params
             ]
         )
-
-
-class CMapper(LanguageMapper):
-    _type_mapping = {
-        "int": "int",
-        "double": "double",
-        "string": "char*",
-    }
-
-    def map(self) -> str:
-        return f"int {self._name}({self.map_params(self._params)});"
-
-    @staticmethod
-    def map_type(dtype: str) -> str:
-        if dtype.startswith("array"):
-            array_type, _ = Parameter.split_array_type(dtype)
-            if array_type == "any":
-                c_type = "void"
-            else:
-                c_type = CMapper.map_type(array_type)
-
-            if array_type != "string":
-                c_type += "*"
-        else:
-            c_type = CMapper._type_mapping[dtype]
-        return c_type
-
-    @staticmethod
-    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
-        c_params = ["void* self"]
-        for name, intent, dtype in params:
-            c_type = CMapper.map_type(dtype)
-            if intent.endswith("out") and dtype != "string":
-                c_type = f"{c_type}*"
-            if intent == "in" or dtype == "string":
-                c_type = f"const {c_type}"
-            c_params.append(f"{c_type} {name}")
-
-            if dtype.startswith("array"):
-                _, dims = Parameter.split_array_type(dtype)
-                c_params += [f"const int {dim}" for dim in dims]
-
-        return ", ".join(c_params)
 
 
 class CxxMapper(LanguageMapper):

--- a/src/bmi_map/bmi_map.py
+++ b/src/bmi_map/bmi_map.py
@@ -5,11 +5,10 @@ from collections.abc import Sequence
 from typing import Any
 from typing import BinaryIO
 
-from bmi_map._mapper import LanguageMapper
-from bmi_map._parameter import Parameter
 from bmi_map.mappers.c import CMapper
 from bmi_map.mappers.cxx import CxxMapper
 from bmi_map.mappers.python import PythonMapper
+from bmi_map.mappers.sidl import SidlMapper
 
 
 def bmi_map(
@@ -52,30 +51,3 @@ def bmi_map(
 
 def _load_interface_definition(file: BinaryIO) -> dict[str, dict[str, Any]]:
     return tomllib.load(file)["bmi"]
-
-
-class SidlMapper(LanguageMapper):
-    def map(self) -> str:
-        return f"int {self._name}({SidlMapper.map_params(self._params)});"
-
-    @staticmethod
-    def map_type(dtype: str) -> str:
-        if dtype.startswith("array"):
-            dtype, dims = Parameter.split_array_type(dtype)
-            if dtype == "any":
-                dtype = ""
-            if dims:
-                return f"array<{dtype.strip()}, {len(dims)}>"
-            else:
-                return f"array<{dtype.strip()},>"
-        else:
-            return dtype
-
-    @staticmethod
-    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
-        return ", ".join(
-            [
-                f"{name} {intent} {SidlMapper.map_type(dtype)}"
-                for name, intent, dtype in params
-            ]
-        )

--- a/src/bmi_map/bmi_map.py
+++ b/src/bmi_map/bmi_map.py
@@ -8,6 +8,7 @@ from typing import BinaryIO
 from bmi_map._mapper import LanguageMapper
 from bmi_map._parameter import Parameter
 from bmi_map.mappers.c import CMapper
+from bmi_map.mappers.cxx import CxxMapper
 
 
 def bmi_map(
@@ -77,69 +78,6 @@ class SidlMapper(LanguageMapper):
                 for name, intent, dtype in params
             ]
         )
-
-
-class CxxMapper(LanguageMapper):
-    _type_mapping = {
-        "int": "int",
-        "double": "double",
-        "string": "std::string",
-    }
-
-    def __init__(self, name: str, params: Sequence[dict[str, str]] | None = None):
-        name = "".join(part.title() for part in name.split("_"))
-        super().__init__(name, params)
-
-    def map(self) -> str:
-        return (
-            f"{self.map_returns(self._params)}"
-            f" {self._name}({self.map_params(self._params)});"
-        )
-
-    @staticmethod
-    def map_type(dtype: str) -> str:
-        if dtype.startswith("array"):
-            array_type, _ = Parameter.split_array_type(dtype)
-            if array_type == "any":
-                cxx_type = "void"
-            elif array_type == "string":
-                cxx_type = "std::vector<std::string>"
-            else:
-                cxx_type = CxxMapper.map_type(array_type)
-
-            if dtype != "string":
-                cxx_type += "*"
-        else:
-            cxx_type = CxxMapper._type_mapping[dtype]
-
-        return cxx_type
-
-    @staticmethod
-    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
-        cxx_params = []
-        for name, intent, dtype in params:
-            cxx_type = CxxMapper.map_type(dtype)
-            if dtype != "string":
-                if intent == "in":
-                    cxx_type = f"const {cxx_type}"
-                elif intent.endswith("out"):
-                    cxx_type = f"{cxx_type}*"
-            if intent.startswith("in"):
-                cxx_params.append(f"{cxx_type} {name}")
-        return ", ".join(cxx_params)
-
-    @staticmethod
-    def map_returns(params: Sequence[tuple[str, str, str]]):
-        returns = [
-            CxxMapper.map_type(dtype) for _, intent, dtype in params if intent == "out"
-        ]
-
-        if len(returns) == 0:
-            return "void"
-        elif len(returns) == 1:
-            return returns[0]
-        else:
-            raise ValueError("multiple return types not allowed")
 
 
 class PythonMapper(LanguageMapper):

--- a/src/bmi_map/mappers/c.py
+++ b/src/bmi_map/mappers/c.py
@@ -1,0 +1,47 @@
+from collections.abc import Sequence
+
+from bmi_map._mapper import LanguageMapper
+from bmi_map._parameter import Parameter
+
+
+class CMapper(LanguageMapper):
+    _type_mapping = {
+        "int": "int",
+        "double": "double",
+        "string": "char*",
+    }
+
+    def map(self) -> str:
+        return f"int {self._name}({self.map_params(self._params)});"
+
+    @staticmethod
+    def map_type(dtype: str) -> str:
+        if dtype.startswith("array"):
+            array_type, _ = Parameter.split_array_type(dtype)
+            if array_type == "any":
+                c_type = "void"
+            else:
+                c_type = CMapper.map_type(array_type)
+
+            if array_type != "string":
+                c_type += "*"
+        else:
+            c_type = CMapper._type_mapping[dtype]
+        return c_type
+
+    @staticmethod
+    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
+        c_params = ["void* self"]
+        for name, intent, dtype in params:
+            c_type = CMapper.map_type(dtype)
+            if intent.endswith("out") and dtype != "string":
+                c_type = f"{c_type}*"
+            if intent == "in" or dtype == "string":
+                c_type = f"const {c_type}"
+            c_params.append(f"{c_type} {name}")
+
+            if dtype.startswith("array"):
+                _, dims = Parameter.split_array_type(dtype)
+                c_params += [f"const int {dim}" for dim in dims]
+
+        return ", ".join(c_params)

--- a/src/bmi_map/mappers/cxx.py
+++ b/src/bmi_map/mappers/cxx.py
@@ -1,0 +1,67 @@
+from collections.abc import Sequence
+
+from bmi_map._mapper import LanguageMapper
+from bmi_map._parameter import Parameter
+
+
+class CxxMapper(LanguageMapper):
+    _type_mapping = {
+        "int": "int",
+        "double": "double",
+        "string": "std::string",
+    }
+
+    def __init__(self, name: str, params: Sequence[dict[str, str]] | None = None):
+        name = "".join(part.title() for part in name.split("_"))
+        super().__init__(name, params)
+
+    def map(self) -> str:
+        return (
+            f"{self.map_returns(self._params)}"
+            f" {self._name}({self.map_params(self._params)});"
+        )
+
+    @staticmethod
+    def map_type(dtype: str) -> str:
+        if dtype.startswith("array"):
+            array_type, _ = Parameter.split_array_type(dtype)
+            if array_type == "any":
+                cxx_type = "void"
+            elif array_type == "string":
+                cxx_type = "std::vector<std::string>"
+            else:
+                cxx_type = CxxMapper.map_type(array_type)
+
+            if dtype != "string":
+                cxx_type += "*"
+        else:
+            cxx_type = CxxMapper._type_mapping[dtype]
+
+        return cxx_type
+
+    @staticmethod
+    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
+        cxx_params = []
+        for name, intent, dtype in params:
+            cxx_type = CxxMapper.map_type(dtype)
+            if dtype != "string":
+                if intent == "in":
+                    cxx_type = f"const {cxx_type}"
+                elif intent.endswith("out"):
+                    cxx_type = f"{cxx_type}*"
+            if intent.startswith("in"):
+                cxx_params.append(f"{cxx_type} {name}")
+        return ", ".join(cxx_params)
+
+    @staticmethod
+    def map_returns(params: Sequence[tuple[str, str, str]]):
+        returns = [
+            CxxMapper.map_type(dtype) for _, intent, dtype in params if intent == "out"
+        ]
+
+        if len(returns) == 0:
+            return "void"
+        elif len(returns) == 1:
+            return returns[0]
+        else:
+            raise ValueError("multiple return types not allowed")

--- a/src/bmi_map/mappers/python.py
+++ b/src/bmi_map/mappers/python.py
@@ -1,0 +1,58 @@
+from collections.abc import Sequence
+
+from bmi_map._mapper import LanguageMapper
+from bmi_map._parameter import Parameter
+
+
+class PythonMapper(LanguageMapper):
+    _type_mapping = {
+        "int": "int",
+        "double": "float",
+        "string": "str",
+    }
+
+    def map(self):
+        return (
+            f"def {self._name}({PythonMapper.map_params(self._params)})"
+            f" -> {PythonMapper.map_returns(self._params)}:"
+        )
+
+    @staticmethod
+    def map_type(dtype: str) -> str:
+        if dtype.startswith("array"):
+            array_type, _ = Parameter.split_array_type(dtype)
+            if array_type == "any":
+                py_type = "Any"
+            elif array_type == "string":
+                py_type = "tuple[str, ...]"
+            else:
+                py_type = PythonMapper.map_type(array_type)
+
+            if array_type != "string":
+                py_type = f"NDArray[{py_type}]"
+        else:
+            py_type = PythonMapper._type_mapping[dtype]
+        return py_type
+
+    @staticmethod
+    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
+        py_params = ["self"] + [
+            f"{name}: {PythonMapper.map_type(dtype)}"
+            for name, intent, dtype in params
+            if intent.startswith("in")
+        ]
+        return ", ".join(py_params)
+
+    @staticmethod
+    def map_returns(params: Sequence[tuple[str, str, str]]):
+        returns = [
+            PythonMapper.map_type(dtype)
+            for _, intent, dtype in params
+            if intent.endswith("out")
+        ]
+        if len(returns) == 0:
+            return "None"
+        elif len(returns) == 1:
+            return returns[0]
+        else:
+            return f"tuple[{', '.join(returns)}]"

--- a/src/bmi_map/mappers/sidl.py
+++ b/src/bmi_map/mappers/sidl.py
@@ -1,0 +1,31 @@
+from collections.abc import Sequence
+
+from bmi_map._mapper import LanguageMapper
+from bmi_map._parameter import Parameter
+
+
+class SidlMapper(LanguageMapper):
+    def map(self) -> str:
+        return f"int {self._name}({SidlMapper.map_params(self._params)});"
+
+    @staticmethod
+    def map_type(dtype: str) -> str:
+        if dtype.startswith("array"):
+            dtype, dims = Parameter.split_array_type(dtype)
+            if dtype == "any":
+                dtype = ""
+            if dims:
+                return f"array<{dtype.strip()}, {len(dims)}>"
+            else:
+                return f"array<{dtype.strip()},>"
+        else:
+            return dtype
+
+    @staticmethod
+    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
+        return ", ".join(
+            [
+                f"{name} {intent} {SidlMapper.map_type(dtype)}"
+                for name, intent, dtype in params
+            ]
+        )

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -1,5 +1,5 @@
 import pytest
-from bmi_map.bmi_map import Parameter
+from bmi_map._parameter import Parameter
 
 
 @pytest.mark.parametrize("array_type", ("int", "double", "string", "any"))


### PR DESCRIPTION
This pull request adds a new subpackage, `mappers`, that holds all of the language mappers as modules.