### PR TITLE
Add load function to load a spec from toml

### DIFF
--- a/src/bmi_map/_main.py
+++ b/src/bmi_map/_main.py
@@ -1,12 +1,12 @@
 import argparse
 import re
 import sys
-import tomllib
 from collections.abc import Sequence
 from functools import partial
 from typing import Any
 
 from bmi_map.bmi_map import bmi_map
+from bmi_map.bmi_map import load
 
 try:
     import pygments
@@ -40,7 +40,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     color = args.color if with_pygments else "never"
 
-    funcs = _filter_keys(tomllib.load(sys.stdin.buffer)["bmi"], include=args.include)
+    funcs = _filter_keys(load(sys.stdin.buffer), include=args.include)
 
     mapped_funcs = bmi_map(funcs, to=args.to)
 

--- a/src/bmi_map/bmi_map.py
+++ b/src/bmi_map/bmi_map.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import tomllib
 from collections.abc import Sequence
-from typing import Any
 from typing import BinaryIO
 
+from bmi_map._parameter import Parameter
 from bmi_map.mappers.c import CMapper
 from bmi_map.mappers.cxx import CxxMapper
 from bmi_map.mappers.python import PythonMapper
@@ -49,5 +49,9 @@ def bmi_map(
     ]
 
 
-def _load_interface_definition(file: BinaryIO) -> dict[str, dict[str, Any]]:
-    return tomllib.load(file)["bmi"]
+def load(stream: BinaryIO) -> dict[str, tuple[Parameter, ...]]:
+    funcs = tomllib.load(stream)["bmi"]
+    return {
+        name: tuple(Parameter(**param) for param in signature["params"])
+        for name, signature in funcs.items()
+    }


### PR DESCRIPTION
This pull request adds a new function, `load`, that loads a spec from a *toml*-formatted file.