### PR TITLE
Change parameters of the map function to accept function name/parameters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 exclude = docs, build, .nox
+ignore = W503
 max-line-length = 88
 max-complexity = 8
 select = B,C,E,F,W,T4,B9

--- a/src/bmi_map/_main.py
+++ b/src/bmi_map/_main.py
@@ -42,11 +42,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     funcs = _filter_keys(load(sys.stdin.buffer), include=args.include)
 
-    mapped_funcs = bmi_map(funcs, to=args.to)
+    mapped_funcs = (bmi_map(func, params, to=args.to) for func, params in funcs.items())
 
     if color == "always" or (color == "auto" and sys.stdout.isatty()):
         highlight = Highlighter(args.to)
-        mapped_funcs = [highlight(mapped_func) for mapped_func in mapped_funcs]
+        mapped_funcs = (highlight(mapped_func) for mapped_func in mapped_funcs)
 
     print("\n".join(mapped_funcs))
 

--- a/src/bmi_map/_mapper.py
+++ b/src/bmi_map/_mapper.py
@@ -4,17 +4,5 @@ from bmi_map._parameter import Parameter
 
 
 class LanguageMapper:
-    def __init__(self, name: str, params: Sequence[dict[str, str]] | None = None):
-        params = () if params is None else params
-
-        if not name.isidentifier():
-            raise ValueError("bad name ({name})")
-
-        self._name = name
-        self._params = tuple(Parameter(**param)._astuple() for param in params)
-
-    def __str__(self) -> str:
-        return self.map()
-
-    def map(self) -> str:
+    def map(self, name: str, params: Sequence[Parameter]) -> str:
         raise NotImplementedError("map")

--- a/src/bmi_map/bmi_map.py
+++ b/src/bmi_map/bmi_map.py
@@ -11,9 +11,7 @@ from bmi_map.mappers.python import PythonMapper
 from bmi_map.mappers.sidl import SidlMapper
 
 
-def bmi_map(
-    funcs: dict[str, dict[str, Sequence[dict[str, str]]]], to="sidl"
-) -> list[str]:
+def bmi_map(name: str, params: Sequence[Parameter], to: str = "sidl") -> str:
     """Map a BMI to a given language.
 
     Parameters
@@ -41,12 +39,9 @@ def bmi_map(
         "sidl": SidlMapper,
     }
 
-    mapper = LANGUAGE_MAPPER[to]
+    mapper = LANGUAGE_MAPPER[to]()
 
-    return [
-        mapper(name, params=func["params"]).map()
-        for name, func in sorted(funcs.items())
-    ]
+    return mapper.map(name, params)
 
 
 def load(stream: BinaryIO) -> dict[str, tuple[Parameter, ...]]:

--- a/src/bmi_map/mappers/python.py
+++ b/src/bmi_map/mappers/python.py
@@ -11,10 +11,10 @@ class PythonMapper(LanguageMapper):
         "string": "str",
     }
 
-    def map(self):
+    def map(self, name: str, params: Sequence[Parameter]) -> str:
         return (
-            f"def {self._name}({PythonMapper.map_params(self._params)})"
-            f" -> {PythonMapper.map_returns(self._params)}:"
+            f"def {name}({PythonMapper.map_params(params)})"
+            f" -> {PythonMapper.map_returns(params)}:"
         )
 
     @staticmethod
@@ -35,20 +35,20 @@ class PythonMapper(LanguageMapper):
         return py_type
 
     @staticmethod
-    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
-        py_params = ["self"] + [
-            f"{name}: {PythonMapper.map_type(dtype)}"
-            for name, intent, dtype in params
-            if intent.startswith("in")
-        ]
-        return ", ".join(py_params)
+    def map_param(param: Parameter) -> str:
+        return f"{param.name}: {PythonMapper.map_type(param.type)}"
 
     @staticmethod
-    def map_returns(params: Sequence[tuple[str, str, str]]):
+    def map_params(params: Sequence[Parameter]) -> str:
+        return ", ".join(
+            ["self"]
+            + [PythonMapper.map_param(p) for p in params if p.intent.startswith("in")]
+        )
+
+    @staticmethod
+    def map_returns(params: Sequence[Parameter]) -> str:
         returns = [
-            PythonMapper.map_type(dtype)
-            for _, intent, dtype in params
-            if intent.endswith("out")
+            PythonMapper.map_type(p.type) for p in params if p.intent.endswith("out")
         ]
         if len(returns) == 0:
             return "None"

--- a/src/bmi_map/mappers/sidl.py
+++ b/src/bmi_map/mappers/sidl.py
@@ -5,8 +5,8 @@ from bmi_map._parameter import Parameter
 
 
 class SidlMapper(LanguageMapper):
-    def map(self) -> str:
-        return f"int {self._name}({SidlMapper.map_params(self._params)});"
+    def map(self, name: str, params: Sequence[Parameter]) -> str:
+        return f"int {name}({SidlMapper.map_params(params)});"
 
     @staticmethod
     def map_type(dtype: str) -> str:
@@ -22,10 +22,9 @@ class SidlMapper(LanguageMapper):
             return dtype
 
     @staticmethod
-    def map_params(params: Sequence[tuple[str, str, str]]) -> str:
-        return ", ".join(
-            [
-                f"{name} {intent} {SidlMapper.map_type(dtype)}"
-                for name, intent, dtype in params
-            ]
-        )
+    def map_param(param: Parameter) -> str:
+        return f"{param.name} {param.intent} {SidlMapper.map_type(param.type)}"
+
+    @staticmethod
+    def map_params(params: Sequence[Parameter]) -> str:
+        return ", ".join(SidlMapper.map_param(p) for p in params)

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -1,4 +1,5 @@
 import pytest
+from bmi_map._parameter import Parameter
 from bmi_map.bmi_map import bmi_map
 
 
@@ -11,9 +12,9 @@ from bmi_map.bmi_map import bmi_map
     ],
 )
 def test_c_one_parameter(intent, expected):
-    params = [{"name": "a", "type": "int", "intent": intent}]
-    mapped_func = bmi_map({"foo": {"params": params}}, to="c")
-    assert mapped_func[0] == expected
+    params = [Parameter(name="a", type="int", intent=intent)]
+    mapped_func = bmi_map("foo", params, to="c")
+    assert mapped_func == expected
 
 
 @pytest.mark.parametrize(
@@ -29,11 +30,11 @@ def test_c_one_parameter(intent, expected):
 )
 def test_c_two_parameter(a_intent, b_intent, expected):
     params = [
-        {"name": "a", "type": "int", "intent": a_intent},
-        {"name": "b", "type": "int", "intent": b_intent},
+        Parameter(name="a", type="int", intent=a_intent),
+        Parameter(name="b", type="int", intent=b_intent),
     ]
-    mapped_func = bmi_map({"foo": {"params": params}}, to="c")
-    assert mapped_func[0] == expected
+    mapped_func = bmi_map("foo", params, to="c")
+    assert mapped_func == expected
 
 
 @pytest.mark.parametrize(
@@ -45,9 +46,9 @@ def test_c_two_parameter(a_intent, b_intent, expected):
     ],
 )
 def test_c_array_intent(intent, expected):
-    p = {"name": "a", "type": "array[int]", "intent": intent}
-    mapped_func = bmi_map({"foo": {"params": [p]}}, to="c")
-    assert mapped_func[0] == expected
+    params = [Parameter(name="a", type="array[int]", intent=intent)]
+    mapped_func = bmi_map("foo", params, to="c")
+    assert mapped_func == expected
 
 
 @pytest.mark.parametrize(
@@ -62,11 +63,11 @@ def test_c_array_intent(intent, expected):
 )
 def test_c_array_with_dimensions(dims, expected):
     params = [
-        {"name": "a", "type": f"array[int,{dims}]", "intent": "in"},
-        {"name": "b", "type": "array[int]", "intent": "in"},
+        Parameter(name="a", intent="in", type=f"array[int,{dims}]"),
+        Parameter(name="b", intent="in", type="array[int]"),
     ]
-    mapped_func = bmi_map({"f": {"params": params}}, to="c")
-    assert mapped_func[0] == expected
+    mapped_func = bmi_map("f", params, to="c")
+    assert mapped_func == expected
 
 
 @pytest.mark.parametrize(
@@ -78,9 +79,9 @@ def test_c_array_with_dimensions(dims, expected):
     ],
 )
 def test_cxx_one_parameter(intent, expected):
-    params = [{"name": "a", "type": "int", "intent": intent}]
-    mapped_func = bmi_map({"foo": {"params": params}}, to="c++")
-    assert mapped_func[0] == expected
+    params = [Parameter(name="a", type="int", intent=intent)]
+    mapped_func = bmi_map("foo", params, to="c++")
+    assert mapped_func == expected
 
 
 @pytest.mark.parametrize(
@@ -95,8 +96,8 @@ def test_cxx_one_parameter(intent, expected):
 )
 def test_cxx_two_parameter(a_intent, b_intent, expected):
     params = [
-        {"name": "a", "type": "int", "intent": a_intent},
-        {"name": "b", "type": "int", "intent": b_intent},
+        Parameter(name="a", type="int", intent=a_intent),
+        Parameter(name="b", type="int", intent=b_intent),
     ]
-    mapped_func = bmi_map({"foo": {"params": params}}, to="c++")
-    assert mapped_func[0] == expected
+    mapped_func = bmi_map("foo", params, to="c++")
+    assert mapped_func == expected


### PR DESCRIPTION
This pull request modifies the parameters of the `LanguageMapper` `map` method. What used to be in the `__init__` method is now in `map` (i.e. the function's name and parameters).