### PR TITLE
Add --spec cli option to read spec from file

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -56,3 +56,29 @@ def lint(session: nox.Session) -> None:
     """Look for lint."""
     session.install("pre-commit")
     session.run("pre-commit", "run", "--all-files")
+
+
+@nox.session(name="gen-toml")
+def gen_toml(session: nox.Session) -> None:
+    """Generate a toml description of the BMI."""
+    session.install(".", "tomli_w")
+
+    script = """\
+import tomli_w
+from bmi_map._bmi import BMI
+
+bmi_toml = tomli_w.dumps(
+    {
+        "bmi": {
+            name: {
+                "params": [p.asdict() for p in params]
+            }
+            for name, params in sorted(BMI.items())
+        }
+    }
+)
+
+print(bmi_toml)
+"""
+    contents = session.run("python", "-c", script, silent=True, external=True)
+    print(contents.strip())

--- a/src/bmi_map/_main.py
+++ b/src/bmi_map/_main.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from functools import partial
 from typing import Any
 
+from bmi_map._bmi import BMI
 from bmi_map.bmi_map import bmi_map
 from bmi_map.bmi_map import load
 
@@ -23,6 +24,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--spec",
+        type=argparse.FileType("rb"),
+        help="spec file from which to read function specifications",
+        default=None,
+    )
+    parser.add_argument(
         "--to",
         help="language for which to generate mappings",
         choices=("c", "c++", "fortran", "python", "sidl"),
@@ -40,7 +47,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     color = args.color if with_pygments else "never"
 
-    funcs = _filter_keys(load(sys.stdin.buffer), include=args.include)
+    spec = BMI if args.spec is None else load(args.spec)
+
+    funcs = _filter_keys(spec, include=args.include)
 
     mapped_funcs = (bmi_map(func, params, to=args.to) for func, params in funcs.items())
 


### PR DESCRIPTION
This pull request adds a new option, `--spec`, to the cli that allows a user to read a *toml*-formatted spec from a file. If not given, use the BMI spec provided by the package (i.e `BMI` from `bmi_map._bmi`).