### PR TITLE
Adding Fortran mapping

### DIFF
--- a/src/bmi_map/bmi_map.py
+++ b/src/bmi_map/bmi_map.py
@@ -9,6 +9,7 @@ from bmi_map._bmi import BMI
 from bmi_map._parameter import Parameter
 from bmi_map.mappers.c import CMapper
 from bmi_map.mappers.cxx import CxxMapper
+from bmi_map.mappers.fortran import FortranMapper
 from bmi_map.mappers.python import PythonMapper
 from bmi_map.mappers.sidl import SidlMapper
 
@@ -37,6 +38,7 @@ def bmi_map(name: str, params: Sequence[Parameter], to: str = "sidl") -> str:
     LANGUAGE_MAPPER = {
         "c": CMapper,
         "c++": CxxMapper,
+        "fortran": FortranMapper,
         "python": PythonMapper,
         "sidl": SidlMapper,
     }

--- a/src/bmi_map/mappers/fortran.py
+++ b/src/bmi_map/mappers/fortran.py
@@ -1,0 +1,21 @@
+from collections.abc import Sequence
+
+from bmi_map._mapper import LanguageMapper
+from bmi_map._parameter import Parameter
+
+
+class FortranMapper(LanguageMapper):
+    _type_mapping = {
+        "int": "int",
+        "double": "double precision",
+        "string": "character(len=*)",
+    }
+
+    def map(self, name: str, params: Sequence[Parameter]) -> str:
+        return (
+            f"function {name}({self.map_params(params)}) result(bmi_status)"
+        )
+
+    @staticmethod
+    def map_params(params: Sequence[Parameter]) -> str:
+        return ", ".join(["this"] + [p.name for p in params])

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -101,3 +101,30 @@ def test_cxx_two_parameter(a_intent, b_intent, expected):
     ]
     mapped_func = bmi_map("foo", params, to="c++")
     assert mapped_func == expected
+
+
+@pytest.mark.parametrize(
+    "expected",
+    [
+        ("function foo(this, a) result(bmi_status)")
+    ]
+)
+def test_fortran_one_parameter(expected):
+    params = [Parameter(name="a", type="int", intent='in')]
+    mapped_func = bmi_map("foo", params, to="fortran")
+    assert mapped_func == expected
+
+
+@pytest.mark.parametrize(
+    "expected",
+    [
+        ("function foo(this, a, b) result(bmi_status)")
+    ]
+)
+def test_fortran_two_parameter(expected):
+    params = [
+        Parameter(name="a", type="int", intent="in"),
+        Parameter(name="b", type="int", intent="in"),
+    ]
+    mapped_func = bmi_map("foo", params, to="fortran")
+    assert mapped_func == expected


### PR DESCRIPTION
Based on the discussions [here](https://forum.csdms.io/t/a-new-home-for-the-bmi-documentation/44), this PR adds Fortran mapping. This outputs only the function signature and so, for Fortran, doesn't include type/kind information. E.g., for `set_value`:

```
function set_value(this, name, src) result(bmi_status)
```

rather than something more complicated like:

```
function set_value_[int|float|double](this, name, src) result(bmi_status)
    class(bmi), intent(inout) :: this
    character(len=*), intent(in) :: name
    [integer|real|double precision], intent(in) :: src(:)
    integer :: bmi_status
```

I'd happy to adapt to a different version that includes the type information, if that would be preferred.

I also added a couple of tests to make sure it works as expected.