### PR TITLE
Fix sidl paramater list

### DIFF
--- a/src/bmi_map/mappers/sidl.py
+++ b/src/bmi_map/mappers/sidl.py
@@ -24,7 +24,7 @@ class SidlMapper(LanguageMapper):
 
     @staticmethod
     def map_param(param: Parameter) -> str:
-        return f"{param.name} {param.intent} {SidlMapper.map_type(param.type)}"
+        return f"{param.intent} {SidlMapper.map_type(param.type)} {param.name}"
 
     @staticmethod
     def map_params(params: Sequence[Parameter]) -> str:

--- a/tests/map_test.py
+++ b/tests/map_test.py
@@ -6,6 +6,20 @@ from bmi_map.bmi_map import bmi_map
 @pytest.mark.parametrize(
     "intent,expected",
     [
+        ("in", "int foo(in int a);"),
+        ("inout", "int foo(inout int a);"),
+        ("out", "int foo(out int a);"),
+    ],
+)
+def test_sidl_one_parameter(intent, expected):
+    params = [Parameter(name="a", type="int", intent=intent)]
+    mapped_func = bmi_map("foo", params, to="sidl")
+    assert mapped_func == expected
+
+
+@pytest.mark.parametrize(
+    "intent,expected",
+    [
         ("in", "int foo(void* self, const int a);"),
         ("inout", "int foo(void* self, int* a);"),
         ("out", "int foo(void* self, int* a);"),


### PR DESCRIPTION
The parameter lists for SIDL were being constructed incorrectly, so I've fixed that. For example,
```java
int get_component_name(name out string);  # incorrect
```
instead of,
```java
int get_component_name(out string name);  # correct
```
The order should be *intent*, *type* and then *parameter name*.