### PR TITLE
Update CI to build the sdist with Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
       - name: Build sdist
         run: |


### PR DESCRIPTION
When running the *sdist* step in our *ci*, we were getting an error from *nox* that was caused by *nox* assuming a newer version of *attrs* than what was installed (https://github.com/wntrblm/nox/pull/962 fixes this by requiring `attrs>=24.1`). The reason we were using an old version of *attrs* in the first place is because the build step used the default installation of Python, which just happened to have an incompatible version of *attrs*. I've modified the *build* step to use *setup-python* to install a clean version of Python 3.13, which ensures the latest version of *attrs* is installed along with *nox*.